### PR TITLE
fixed wrong calculation of leaders positions

### DIFF
--- a/GWO.py
+++ b/GWO.py
@@ -57,17 +57,17 @@ def GWO(objf,lb,ub,dim,SearchAgents_no,Max_iter):
             # Update Alpha, Beta, and Delta
             if fitness<Alpha_score :
                 Alpha_score=fitness; # Update alpha
-                Alpha_pos=Positions[i,:]
+                Alpha_pos=Positions[i,:].copy()
             
             
             if (fitness>Alpha_score and fitness<Beta_score ):
                 Beta_score=fitness  # Update beta
-                Beta_pos=Positions[i,:]
+                Beta_pos=Positions[i,:].copy()
             
             
             if (fitness>Alpha_score and fitness>Beta_score and fitness<Delta_score): 
                 Delta_score=fitness # Update delta
-                Delta_pos=Positions[i,:]
+                Delta_pos=Positions[i,:].copy()
             
         
         


### PR DESCRIPTION
In lines 60, 65 and 70. The leader's position is assigned the  valued of "Positions[i,:]". This actually passes the variable "Positions[i,:]" by reference and hence the leader position is changed in the next loop even if the current solution does not have a lower/higher fitness.
So, we need to copy - by value not by reference - the current position vector into the leaders variables.